### PR TITLE
Fix 6

### DIFF
--- a/CertVal.ApiService/Controllers/V1/NotificationsController.cs
+++ b/CertVal.ApiService/Controllers/V1/NotificationsController.cs
@@ -58,7 +58,8 @@ public class NotificationsController : ControllerBase
             ChannelType = request.ChannelType,
             ChannelConfig = request.ChannelConfig,
             RecipientUserIds = request.RecipientUserIds,
-            Frequency = request.Frequency
+            Frequency = request.Frequency,
+            RecipientAggregationMode = request.RecipientAggregationMode
         };
 
         var result = await _mediator.Send(command, cancellationToken);

--- a/CertVal.Application/DTOs/NotificationDtos.cs
+++ b/CertVal.Application/DTOs/NotificationDtos.cs
@@ -13,6 +13,7 @@ public record NotificationRuleDto
     public string Frequency { get; init; } = string.Empty;
     public string ChannelType { get; init; } = string.Empty;
     public string ChannelConfig { get; init; } = string.Empty;
+    public RecipientAggregationMode RecipientAggregationMode { get; init; }
     public DateTime CreatedAt { get; init; }
     public DateTime UpdatedAt { get; init; }
 }
@@ -34,12 +35,14 @@ public record CreateNotificationRuleRequest
     public List<Guid>? RecipientUserIds { get; init; }
 
     public NotificationFrequency Frequency { get; init; } = NotificationFrequency.Once;
+    public RecipientAggregationMode RecipientAggregationMode { get; init; } = RecipientAggregationMode.Individual;
 }
 
 public record UpdateNotificationRuleRequest
 {
     [Required]
     public string ChannelConfig { get; init; } = "{}";
+    public RecipientAggregationMode? RecipientAggregationMode { get; init; }
 }
 
 public record NotificationHistoryDto

--- a/CertVal.Application/Features/Notifications/Commands/CreateNotificationRule.cs
+++ b/CertVal.Application/Features/Notifications/Commands/CreateNotificationRule.cs
@@ -19,6 +19,7 @@ public record CreateNotificationRuleCommand : IRequest<Result<NotificationRuleDt
     public string ChannelConfig { get; init; } = string.Empty;
     public NotificationFrequency Frequency { get; init; }
     public List<Guid>? RecipientUserIds { get; init; }
+    public RecipientAggregationMode RecipientAggregationMode { get; init; } = RecipientAggregationMode.Individual;
 }
 
 public class CreateNotificationRuleCommandValidator : AbstractValidator<CreateNotificationRuleCommand>
@@ -107,6 +108,8 @@ public class CreateNotificationRuleCommandHandler : IRequestHandler<CreateNotifi
             request.Frequency
         );
 
+        rule.SetRecipientAggregationMode(request.RecipientAggregationMode);
+
         await _unitOfWork.NotificationRules.AddAsync(rule, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
@@ -120,6 +123,7 @@ public class CreateNotificationRuleCommandHandler : IRequestHandler<CreateNotifi
             Frequency = rule.Frequency.ToString(),
             ChannelType = rule.ChannelType.ToString(),
             ChannelConfig = rule.ChannelConfig,
+            RecipientAggregationMode = rule.RecipientAggregationMode,
             CreatedAt = rule.CreatedAt,
             UpdatedAt = rule.UpdatedAt
         };

--- a/CertVal.Application/Features/Notifications/Commands/ToggleNotificationRule.cs
+++ b/CertVal.Application/Features/Notifications/Commands/ToggleNotificationRule.cs
@@ -60,6 +60,7 @@ public class ToggleNotificationRuleCommandHandler : IRequestHandler<ToggleNotifi
             Frequency = rule.Frequency.ToString(),
             ChannelType = rule.ChannelType.ToString(),
             ChannelConfig = rule.ChannelConfig,
+            RecipientAggregationMode = rule.RecipientAggregationMode,
             CreatedAt = rule.CreatedAt,
             UpdatedAt = rule.UpdatedAt
         };

--- a/CertVal.Application/Features/Notifications/Commands/UpdateNotificationRule.cs
+++ b/CertVal.Application/Features/Notifications/Commands/UpdateNotificationRule.cs
@@ -1,6 +1,7 @@
 using CertVal.Application.Common.Interfaces;
 using CertVal.Application.Common.Models;
 using CertVal.Application.DTOs;
+using CertVal.Core.Enums;
 using CertVal.Core.Repositories;
 using FluentValidation;
 using MediatR;
@@ -12,6 +13,7 @@ public record UpdateNotificationRuleCommand : IRequest<Result<NotificationRuleDt
     public Guid WorkspaceId { get; init; }
     public Guid RuleId { get; init; }
     public string ChannelConfig { get; init; } = string.Empty;
+    public RecipientAggregationMode? RecipientAggregationMode { get; init; }
 }
 
 public class UpdateNotificationRuleCommandValidator : AbstractValidator<UpdateNotificationRuleCommand>
@@ -50,6 +52,10 @@ public class UpdateNotificationRuleCommandHandler : IRequestHandler<UpdateNotifi
             return Result.Failure<NotificationRuleDto>("Notification rule not found");
 
         rule.UpdateConfig(request.ChannelConfig);
+        if (request.RecipientAggregationMode.HasValue)
+        {
+            rule.SetRecipientAggregationMode(request.RecipientAggregationMode.Value);
+        }
 
         await _unitOfWork.NotificationRules.UpdateAsync(rule, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
@@ -64,6 +70,7 @@ public class UpdateNotificationRuleCommandHandler : IRequestHandler<UpdateNotifi
             Frequency = rule.Frequency.ToString(),
             ChannelType = rule.ChannelType.ToString(),
             ChannelConfig = rule.ChannelConfig,
+            RecipientAggregationMode = rule.RecipientAggregationMode,
             CreatedAt = rule.CreatedAt,
             UpdatedAt = rule.UpdatedAt
         };

--- a/CertVal.Application/Features/Notifications/Queries/GetNotificationRules.cs
+++ b/CertVal.Application/Features/Notifications/Queries/GetNotificationRules.cs
@@ -48,6 +48,7 @@ public class GetNotificationRulesQueryHandler : IRequestHandler<GetNotificationR
             Frequency = r.Frequency.ToString(),
             ChannelType = r.ChannelType.ToString(),
             ChannelConfig = r.ChannelConfig,
+            RecipientAggregationMode = r.RecipientAggregationMode,
             CreatedAt = r.CreatedAt,
             UpdatedAt = r.UpdatedAt
         });

--- a/CertVal.Core/Entities/NotificationRule.cs
+++ b/CertVal.Core/Entities/NotificationRule.cs
@@ -11,13 +11,13 @@ public class NotificationRule : BaseEntity
     public string Name { get; private set; } = string.Empty;
     public bool IsEnabled { get; private set; } = true;
 
-    // Notification timing
     public int DaysBeforeExpiry { get; private set; }
     public NotificationFrequency Frequency { get; private set; } = NotificationFrequency.Once;
 
-    // Channel configuration
     public NotificationChannelType ChannelType { get; private set; } = NotificationChannelType.Email;
     public string ChannelConfig { get; private set; } = "{}"; // JSON configuration
+
+    public RecipientAggregationMode RecipientAggregationMode { get; private set; } = RecipientAggregationMode.Individual;
 
     public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; private set; } = DateTime.UtcNow;
@@ -52,6 +52,15 @@ public class NotificationRule : BaseEntity
         rule.AddDomainEvent(new NotificationRuleCreatedEvent(rule.Id, rule.WorkspaceId, rule.Name, rule.DaysBeforeExpiry));
 
         return rule;
+    }
+
+    public void SetRecipientAggregationMode(RecipientAggregationMode mode)
+    {
+        if (RecipientAggregationMode != mode)
+        {
+            RecipientAggregationMode = mode;
+            UpdatedAt = DateTime.UtcNow;
+        }
     }
 
     public void Toggle()

--- a/CertVal.Core/Enums/RecipientAggregationMode.cs
+++ b/CertVal.Core/Enums/RecipientAggregationMode.cs
@@ -1,0 +1,7 @@
+namespace CertVal.Core.Enums;
+
+public enum RecipientAggregationMode
+{
+    Individual = 0,
+    SingleEmailToAll = 1
+}

--- a/CertVal.Core/Messaging/EmailNotificationMessage.cs
+++ b/CertVal.Core/Messaging/EmailNotificationMessage.cs
@@ -8,6 +8,8 @@ public record EmailNotificationMessage
     public EmailNotificationType Type { get; init; }
     public string ToEmail { get; init; } = string.Empty;
     public string ToName { get; init; } = string.Empty;
+    public IReadOnlyCollection<string>? Recipients { get; init; }
+    public bool IsAggregated => Recipients is { Count: > 0 };
     public Dictionary<string, object> Data { get; init; } = new();
     public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
     public int RetryCount { get; init; } = 0;

--- a/CertVal.Core/Messaging/IEmailNotificationPublisher.cs
+++ b/CertVal.Core/Messaging/IEmailNotificationPublisher.cs
@@ -13,4 +13,7 @@ public interface IEmailNotificationPublisher : IAsyncDisposable
     Task PublishCertificateExpiringAsync(string email, string workspaceName, string certificateSubject,
         string certificateIssuer, DateTime expiryDate, int daysUntilExpiry,
         CancellationToken cancellationToken = default);
+    Task PublishCertificateExpiringAggregatedAsync(IEnumerable<string> emails, string workspaceName, string certificateSubject,
+        string certificateIssuer, DateTime expiryDate, int daysUntilExpiry,
+        CancellationToken cancellationToken = default);
 }

--- a/CertVal.EmailService/Configuration/EmailServiceConfiguration.cs
+++ b/CertVal.EmailService/Configuration/EmailServiceConfiguration.cs
@@ -12,6 +12,7 @@ public class EmailServiceConfiguration
     public string BaseUrl { get; set; } = string.Empty;
     public int MaxRetryAttempts { get; set; } = 3;
     public TimeSpan RetryDelay { get; set; } = TimeSpan.FromMinutes(5);
+    public bool AggregatedUseBcc { get; set; } = false;
 }
 
 public class SmtpSettings

--- a/CertVal.EmailService/Services/SmtpEmailService.cs
+++ b/CertVal.EmailService/Services/SmtpEmailService.cs
@@ -43,12 +43,19 @@ public class SmtpEmailService : IEmailService
 
             await SendEmailInternal(mimeMessage).ConfigureAwait(false);
 
-            _logger.LogInformation("Email sent successfully to {ToEmail}", message.ToEmail);
+            if (message.IsAggregated)
+            {
+                _logger.LogInformation("Aggregated email sent successfully to {Count} recipients (primary: {Primary})", message.Recipients!.Count, message.ToEmail);
+            }
+            else
+            {
+                _logger.LogInformation("Email sent successfully to {ToEmail}", message.ToEmail);
+            }
             return true;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send email to {ToEmail}: {Error}", message.ToEmail, ex.Message);
+            _logger.LogError(ex, "Failed to send email (aggregated={Aggregated}) to {ToEmail}: {Error}", message.IsAggregated, message.ToEmail, ex.Message);
             return false;
         }
     }
@@ -70,11 +77,20 @@ public class SmtpEmailService : IEmailService
 
     private static void ValidateMessage(EmailNotificationMessage message)
     {
-        if (string.IsNullOrWhiteSpace(message.ToEmail))
-            throw new ArgumentException("Recipient email is required", nameof(message));
-
-        if (!MailboxAddress.TryParse(message.ToEmail, out _))
-            throw new ArgumentException("Recipient email is invalid", nameof(message));
+        if (message.IsAggregated)
+        {
+            if (message.Recipients is null || message.Recipients.Count == 0)
+                throw new ArgumentException("Aggregated message requires recipients list", nameof(message));
+            if (string.IsNullOrWhiteSpace(message.ToEmail))
+                throw new ArgumentException("Primary ToEmail is required for aggregated message (can be placeholder)", nameof(message));
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(message.ToEmail))
+                throw new ArgumentException("Recipient email is required", nameof(message));
+            if (!MailboxAddress.TryParse(message.ToEmail, out _))
+                throw new ArgumentException("Recipient email is invalid", nameof(message));
+        }
     }
 
     private MimeMessage CreateMimeMessage(EmailNotificationMessage message, Models.EmailTemplate template)
@@ -89,6 +105,14 @@ public class SmtpEmailService : IEmailService
 
         var to = CreateMailbox(message.ToName, message.ToEmail);
         mimeMessage.To.Add(to);
+
+        if (message.IsAggregated && message.Recipients is { Count: > 0 })
+            foreach (var rcpt in message.Recipients)
+                if (MailboxAddress.TryParse(rcpt, out var mb))
+                    if (_config.AggregatedUseBcc)
+                        mimeMessage.Bcc.Add(mb);
+                    else
+                        mimeMessage.To.Add(mb);
 
 
         var bodyBuilder = new BodyBuilder

--- a/CertVal.Infrastructure/Data/Configurations/NotificationRuleConfiguration.cs
+++ b/CertVal.Infrastructure/Data/Configurations/NotificationRuleConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using CertVal.Core.Entities;
+using CertVal.Core.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -31,6 +32,11 @@ public class NotificationRuleConfiguration : IEntityTypeConfiguration<Notificati
             .IsRequired()
             .HasMaxLength(2000)
             .HasDefaultValue("{}");
+
+        builder.Property(nr => nr.RecipientAggregationMode)
+            .IsRequired()
+            .HasConversion<int>()
+            .HasDefaultValue(RecipientAggregationMode.Individual);
 
         builder.Property(nr => nr.IsEnabled)
             .HasDefaultValue(true);

--- a/CertVal.Infrastructure/Events/EmailNotificationEventHandlers.cs
+++ b/CertVal.Infrastructure/Events/EmailNotificationEventHandlers.cs
@@ -203,13 +203,14 @@ public class EmailNotificationEventHandlers :
                 continue;
             }
 
-            foreach (var user in recipients)
+            if (rule.RecipientAggregationMode == RecipientAggregationMode.SingleEmailToAll)
             {
+                var aggregatedEmails = recipients.Select(r => r.Email).Distinct().ToList();
                 try
                 {
                     var notification = NotificationHistory.Create(
                         rule.Id, certificateId, NotificationChannelType.Email,
-                        user.Email,
+                        string.Join(",", aggregatedEmails),
                         GenerateEmailSubject(certificate, daysUntilExpiry, isExpired),
                         GenerateEmailMessage(certificate, workspace, daysUntilExpiry, isExpired),
                         DateTime.UtcNow
@@ -218,8 +219,8 @@ public class EmailNotificationEventHandlers :
                     await _unitOfWork.NotificationHistory.AddAsync(notification, cancellationToken);
                     await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-                    await _emailPublisher.PublishCertificateExpiringAsync(
-                        user.Email,
+                    await _emailPublisher.PublishCertificateExpiringAggregatedAsync(
+                        aggregatedEmails,
                         workspace.Name,
                         certificate.Subject,
                         certificate.Issuer,
@@ -230,20 +231,65 @@ public class EmailNotificationEventHandlers :
                     notification.MarkAsSent();
                     await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-                    _logger.LogInformation("Sent certificate notification for certificate {CertificateId} to {Email} via rule {RuleId}",
-                       certificateId, user.Email, rule.Id);
+                    _logger.LogInformation("Sent aggregated certificate notification for certificate {CertificateId} to {Count} recipients via rule {RuleId}",
+                        certificateId, aggregatedEmails.Count, rule.Id);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to send certificate notification for certificate {CertificateId} to {Email}",
-                        certificateId, user.Email);
-
+                    _logger.LogError(ex, "Failed to send aggregated certificate notification for certificate {CertificateId}", certificateId);
                     var failedNotification = await _unitOfWork.NotificationHistory
                         .GetLastNotificationAsync(certificateId, rule.Id, cancellationToken);
                     if (failedNotification != null && failedNotification.Status == NotificationStatus.Pending)
                     {
                         failedNotification.MarkAsFailed(ex.Message);
                         await _unitOfWork.SaveChangesAsync(cancellationToken);
+                    }
+                }
+            }
+            else
+            {
+                foreach (var user in recipients)
+                {
+                    try
+                    {
+                        var notification = NotificationHistory.Create(
+                            rule.Id, certificateId, NotificationChannelType.Email,
+                            user.Email,
+                            GenerateEmailSubject(certificate, daysUntilExpiry, isExpired),
+                            GenerateEmailMessage(certificate, workspace, daysUntilExpiry, isExpired),
+                            DateTime.UtcNow
+                        );
+
+                        await _unitOfWork.NotificationHistory.AddAsync(notification, cancellationToken);
+                        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+                        await _emailPublisher.PublishCertificateExpiringAsync(
+                            user.Email,
+                            workspace.Name,
+                            certificate.Subject,
+                            certificate.Issuer,
+                            expiryDate,
+                            daysUntilExpiry,
+                            cancellationToken);
+
+                        notification.MarkAsSent();
+                        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+                        _logger.LogInformation("Sent certificate notification for certificate {CertificateId} to {Email} via rule {RuleId}",
+                           certificateId, user.Email, rule.Id);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to send certificate notification for certificate {CertificateId} to {Email}",
+                            certificateId, user.Email);
+
+                        var failedNotification = await _unitOfWork.NotificationHistory
+                            .GetLastNotificationAsync(certificateId, rule.Id, cancellationToken);
+                        if (failedNotification != null && failedNotification.Status == NotificationStatus.Pending)
+                        {
+                            failedNotification.MarkAsFailed(ex.Message);
+                            await _unitOfWork.SaveChangesAsync(cancellationToken);
+                        }
                     }
                 }
             }

--- a/CertVal.Infrastructure/Messaging/RabbitMqEmailNotificationPublisher.cs
+++ b/CertVal.Infrastructure/Messaging/RabbitMqEmailNotificationPublisher.cs
@@ -151,6 +151,40 @@ public class RabbitMqEmailNotificationPublisher : IEmailNotificationPublisher, I
         await PublishAsync(message, cancellationToken);
     }
 
+    public async Task PublishCertificateExpiringAggregatedAsync(IEnumerable<string> emails, string workspaceName,
+        string certificateSubject, string certificateIssuer, DateTime expiryDate, int daysUntilExpiry,
+        CancellationToken cancellationToken = default)
+    {
+        var emailList = emails.Distinct().ToList();
+        if (emailList.Count == 0) return;
+
+        var notificationType = daysUntilExpiry <= 0
+            ? EmailNotificationType.CertificateExpired
+            : EmailNotificationType.CertificateExpiring;
+
+        var primary = emailList[0];
+        var message = new EmailNotificationMessage
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            Type = notificationType,
+            ToEmail = primary,
+            ToName = string.Empty,
+            Recipients = emailList,
+            Data = new Dictionary<string, object>
+            {
+                ["WorkspaceName"] = workspaceName,
+                ["CertificateSubject"] = certificateSubject,
+                ["CertificateIssuer"] = certificateIssuer,
+                ["ExpiryDate"] = expiryDate,
+                ["DaysUntilExpiry"] = daysUntilExpiry
+            },
+            CreatedAt = DateTime.UtcNow,
+            RetryCount = 0
+        };
+
+        await PublishAsync(message, cancellationToken);
+    }
+
     private IModel CreateChannel()
     {
         try

--- a/CertVal.Infrastructure/Migrations/20250921094844_InitialCreate.cs
+++ b/CertVal.Infrastructure/Migrations/20250921094844_InitialCreate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable

--- a/CertVal.Infrastructure/Migrations/20250925201647_FixNotificationHistoryCascadeDelete.Designer.cs
+++ b/CertVal.Infrastructure/Migrations/20250925201647_FixNotificationHistoryCascadeDelete.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CertVal.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CertVal.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250925201647_FixNotificationHistoryCascadeDelete")]
+    partial class FixNotificationHistoryCascadeDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CertVal.Infrastructure/Migrations/20250925201647_FixNotificationHistoryCascadeDelete.cs
+++ b/CertVal.Infrastructure/Migrations/20250925201647_FixNotificationHistoryCascadeDelete.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CertVal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixNotificationHistoryCascadeDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_NotificationHistory_Certificates_CertificateId",
+                table: "NotificationHistory");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_NotificationHistory_Certificates_CertificateId",
+                table: "NotificationHistory",
+                column: "CertificateId",
+                principalTable: "Certificates",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_NotificationHistory_Certificates_CertificateId",
+                table: "NotificationHistory");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_NotificationHistory_Certificates_CertificateId",
+                table: "NotificationHistory",
+                column: "CertificateId",
+                principalTable: "Certificates",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+    }
+}

--- a/CertVal.Web/src/lib/i18n/index.ts
+++ b/CertVal.Web/src/lib/i18n/index.ts
@@ -365,7 +365,13 @@ export const translations = {
             noWorkspaces: 'У вас ще немає робочих просторів.',
             createFirstWorkspace: 'Створіть свій перший робочий простір, щоб керувати сповіщеннями.',
             recipients: 'Отримувачі',
-            viewRecipients: 'Переглянути отримувачів'
+            viewRecipients: 'Переглянути отримувачів',
+            recipientAggregation: 'Агрегація отримувачів',
+            recipientAggregationHelp: 'Якщо увімкнено — буде надіслано один лист усім отримувачам.',
+            aggregatedBadge: 'Агреговано',
+            individualBadge: 'Індивідуально',
+            aggregationIndividualOption: 'Окремий лист кожному',
+            aggregationAllOption: 'Один лист для всіх'
         },
         profile: {
             title: 'Профіль користувача',
@@ -777,7 +783,13 @@ export const translations = {
             noWorkspaces: "You don't have any workspaces yet.",
             createFirstWorkspace: 'Create your first workspace to manage notifications.',
             recipients: 'Recipients',
-            viewRecipients: 'View Recipients'
+            viewRecipients: 'View Recipients',
+            recipientAggregation: 'Recipient Aggregation',
+            recipientAggregationHelp: 'When enabled, a single email will be sent to all selected recipients.',
+            aggregatedBadge: 'Aggregated',
+            individualBadge: 'Individual',
+            aggregationIndividualOption: 'Separate email to each',
+            aggregationAllOption: 'One email to all recipients'
         },
         profile: {
             title: 'User Profile',

--- a/CertVal.Web/src/lib/types/index.ts
+++ b/CertVal.Web/src/lib/types/index.ts
@@ -157,6 +157,7 @@ export interface NotificationRule {
     frequency: string;
     channelType: string;
     channelConfig: string;
+    recipientAggregationMode: 'Individual' | 'SingleEmailToAll';
     createdAt: string;
     updatedAt: string;
 }
@@ -184,6 +185,7 @@ export interface CreateNotificationRuleRequest {
     channelType: 'Email' | 'Webhook' | 'Slack' | 'Telegram';
     channelConfig: string;
     frequency: 'Once' | 'Daily' | 'Weekly' | 'Monthly';
+    recipientAggregationMode?: 'Individual' | 'SingleEmailToAll';
 }
 export interface UpdateUserRequest {
     firstName: string;

--- a/CertVal.Web/src/routes/notifications/+page.svelte
+++ b/CertVal.Web/src/routes/notifications/+page.svelte
@@ -43,7 +43,8 @@
 		channelType: 'Email',
 		channelConfig: '{}',
 		frequency: 'Once',
-		recipientUserIds: []
+		recipientUserIds: [],
+		recipientAggregationMode: 'SingleEmailToAll'
 	});
 	let webhookUrl = $state('');
 	let errors = $state<Record<string, string>>({});
@@ -156,7 +157,8 @@
 			channelType: 'Email',
 			channelConfig: '{}',
 			frequency: 'Once',
-			recipientUserIds: []
+			recipientUserIds: [],
+			recipientAggregationMode: 'SingleEmailToAll'
 		};
 		webhookUrl = '';
 		errors = {};
@@ -168,7 +170,7 @@
 		isProcessing = true;
 		errors = {};
 
-		const { recipientUserIds, ...restOfForm } = createForm;
+		const { recipientUserIds, recipientAggregationMode, ...restOfForm } = createForm;
 
 		let payload: any = { ...restOfForm };
 
@@ -179,6 +181,7 @@
 				return;
 			}
 			payload.recipientUserIds = recipientUserIds;
+			payload.recipientAggregationMode = recipientAggregationMode;
 		} else if (createForm.channelType === 'Webhook') {
 			try {
 				new URL(webhookUrl);
@@ -272,7 +275,7 @@
 	<div class="flex items-center justify-between">
 		<div>
 			<h1 class="text-3xl font-bold">{t('notifications.title', $language)}</h1>
-			<p class="mt-1 text-base-content/70">{t('notifications.subtitle', $language)}</p>
+			<p class="text-base-content/70 mt-1">{t('notifications.subtitle', $language)}</p>
 		</div>
 		<div>
 			<Button
@@ -299,12 +302,12 @@
 	{:else if workspaces.length === 0}
 		<div class="py-16 text-center">
 			<div
-				class="mx-auto flex h-24 w-24 items-center justify-center rounded-full bg-base-100 text-base-content/50 shadow-inner"
+				class="bg-base-100 text-base-content/50 mx-auto flex h-24 w-24 items-center justify-center rounded-full shadow-inner"
 			>
 				<Icon name="workspaces" class="h-12 w-12" />
 			</div>
 			<h3 class="mt-4 text-xl font-semibold">{t('notifications.noWorkspaces', $language)}</h3>
-			<p class="mt-2 text-base-content/60">{t('notifications.createFirstWorkspace', $language)}</p>
+			<p class="text-base-content/60 mt-2">{t('notifications.createFirstWorkspace', $language)}</p>
 			<div class="mt-6 flex justify-center">
 				<Button onclick={() => goto('/workspaces')}>
 					{t('workspaces.create', $language)}
@@ -325,7 +328,7 @@
 			{#if rules.length === 0}
 				<div class="py-16 text-center">
 					<h3 class="text-xl font-semibold">{t('notifications.noRules', $language)}</h3>
-					<p class="mt-2 text-base-content/60">{t('notifications.createFirstRule', $language)}</p>
+					<p class="text-base-content/60 mt-2">{t('notifications.createFirstRule', $language)}</p>
 					<div class="mt-6 flex justify-center">
 						<Button onclick={openCreateModal}>
 							{t('notifications.createRule', $language)}
@@ -338,11 +341,11 @@
 					{@const recipients = getRecipientsForRule(rule)}
 					{@const isOpen = openRuleId === rule.id}
 					<div
-						class="rounded-xl border border-base-content/10 bg-base-100 shadow-sm transition-colors"
+						class="border-base-content/10 bg-base-100 rounded-xl border shadow-sm transition-colors"
 					>
 						<div
 							role="button"
-							class="group flex w-full items-start gap-4 px-5 py-4 text-left focus:outline-none focus-visible:ring focus-visible:ring-primary/40"
+							class="focus-visible:ring-primary/40 group flex w-full items-start gap-4 px-5 py-4 text-left focus:outline-none focus-visible:ring"
 							aria-expanded={isOpen}
 							tabindex="0"
 							onclick={() => toggleRule(rule.id)}
@@ -355,7 +358,7 @@
 						>
 							<div class="flex-grow space-y-1">
 								<div class="flex items-start justify-between gap-4">
-									<p class="leading-tight font-semibold">{rule.name}</p>
+									<p class="font-semibold leading-tight">{rule.name}</p>
 									<div class="flex items-center gap-3">
 										<div class="flex items-center gap-2">
 											<span
@@ -367,7 +370,7 @@
 											</span>
 											<button
 												type="button"
-												class="inline-flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-base-200 focus:outline-none focus-visible:ring focus-visible:ring-primary/40"
+												class="hover:bg-base-200 focus-visible:ring-primary/40 inline-flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 focus:outline-none focus-visible:ring"
 												onclick={(e) => e.stopPropagation()}
 												onkeydown={(e) => {
 													if (e.key === 'Enter' || e.key === ' ') {
@@ -405,9 +408,18 @@
 									{t('notifications.daysBeforeExpirySuffix', $language)}.
 									{t('notifications.channel', $language)} <strong>{rule.channelType}</strong>.
 									{t('notifications.frequency', $language)}: <strong>{rule.frequency}</strong>.
+									{#if rule.channelType === 'Email'}
+										<span class="ml-1">
+											{#if rule.recipientAggregationMode === 'SingleEmailToAll'}
+												<strong>[{t('notifications.aggregatedBadge', $language)}]</strong>
+											{:else}
+												<strong>[{t('notifications.individualBadge', $language)}]</strong>
+											{/if}
+										</span>
+									{/if}
 								</p>
 								{#if isDisabled}
-									<div role="alert" class="mt-2 alert alert-warning p-2 text-xs">
+									<div role="alert" class="alert alert-warning mt-2 p-2 text-xs">
 										<span>{t('notifications.disabledInProfileWarning', $language)}</span>
 									</div>
 								{/if}
@@ -417,7 +429,7 @@
 								aria-hidden="true"
 							>
 								<svg
-									class="h-4 w-4 text-base-content/60 transition-transform"
+									class="text-base-content/60 h-4 w-4 transition-transform"
 									viewBox="0 0 20 20"
 									fill="none"
 									stroke="currentColor"
@@ -430,13 +442,13 @@
 							</div>
 						</div>
 						{#if isOpen && rule.channelType === 'Email' && recipients.length > 0}
-							<div class="border-t border-base-content/10 px-5 py-3">
+							<div class="border-base-content/10 border-t px-5 py-3">
 								<p class="mb-2 text-sm font-medium">
 									{t('notifications.recipients', $language)} ({recipients.length})
 								</p>
 								<div class="max-h-48 space-y-2 overflow-y-auto pr-1">
 									{#each recipients as member (member.userId)}
-										<div class="flex items-center gap-3 rounded-lg bg-base-200/60 p-2">
+										<div class="bg-base-200/60 flex items-center gap-3 rounded-lg p-2">
 											<UserAvatar
 												firstName={member.user.firstName}
 												lastName={member.user.lastName}
@@ -446,7 +458,7 @@
 											<div class="flex flex-col">
 												<span class="label-text">{member.user.fullName}</span>
 												{#if selectedWorkspace && member.userId === selectedWorkspace.ownerId}
-													<span class="mt-1 badge badge-xs badge-primary"
+													<span class="badge badge-xs badge-primary mt-1"
 														>{t('common.owner', $language)}</span
 													>
 												{/if}
@@ -490,16 +502,15 @@
 
 		{#if createForm.channelType === 'Email'}
 			<fieldset class="form-control">
-				<legend class="label">
-					<span class="label-text font-medium">{t('notifications.recipients', $language)}</span>
-				</legend>
+				<label class="label" for="recipient-aggregation-mode">
+					<span class="label-text">{t('notifications.recipientAggregation', $language)}</span>
+				</label>
 				<div
-					class="max-h-48 space-y-1 overflow-y-auto rounded-lg border border-base-content/20 p-2"
+					id="recipient-aggregation-mode"
+					class="border-base-content/20 max-h-48 space-y-1 overflow-y-auto rounded-lg border p-2"
 				>
 					{#each workspaceMembers as member (member.userId)}
-						<label
-							class="flex cursor-pointer items-center justify-between rounded-lg p-2 transition-colors hover:bg-base-200"
-						>
+						<div class="bg-base-200/60 flex items-center justify-between gap-3 rounded-lg p-2">
 							<div class="flex items-center gap-3">
 								<UserAvatar
 									firstName={member.user.firstName}
@@ -510,7 +521,7 @@
 								<div class="flex flex-col">
 									<span class="label-text">{member.user.fullName}</span>
 									{#if selectedWorkspace && member.userId === selectedWorkspace.ownerId}
-										<span class="mt-1 badge badge-xs badge-primary"
+										<span class="badge badge-xs badge-primary mt-1"
 											>{t('common.owner', $language)}</span
 										>
 									{/if}
@@ -522,9 +533,32 @@
 								value={member.userId}
 								class="checkbox checkbox-primary"
 							/>
-						</label>
+						</div>
 					{/each}
 				</div>
+
+				{#if createForm.recipientUserIds.length > 1}
+					<div class="mt-3">
+						<label class="label" for="recipient-aggregation-select">
+							<span class="label-text">{t('notifications.recipientAggregation', $language)}</span>
+						</label>
+						<select
+							id="recipient-aggregation-select"
+							bind:value={createForm.recipientAggregationMode}
+							class="select select-bordered w-full"
+						>
+							<option value="SingleEmailToAll">
+								{t('notifications.aggregationAllOption', $language)}
+							</option>
+							<option value="Individual">
+								{t('notifications.aggregationIndividualOption', $language)}
+							</option>
+						</select>
+						<p class="mt-1 text-xs opacity-70">
+							{t('notifications.recipientAggregationHelp', $language)}
+						</p>
+					</div>
+				{/if}
 			</fieldset>
 		{:else if createForm.channelType === 'Webhook'}
 			<Input
@@ -579,7 +613,7 @@
 			<p class="py-8 text-center">{t('notifications.noHistory', $language)}</p>
 		{:else}
 			{#each history as item}
-				<div class="rounded-lg border border-base-content/10 p-2 text-sm">
+				<div class="border-base-content/10 rounded-lg border p-2 text-sm">
 					<div class="flex justify-between">
 						<span class="max-w-xs truncate font-semibold">{item.subject}</span>
 						<span class="badge badge-sm {item.status === 'Sent' ? 'badge-success' : 'badge-error'}"


### PR DESCRIPTION
Fixes #6 
AI:
This pull request introduces support for configuring recipient aggregation for notification rules, enabling notifications to be sent either individually or as a single aggregated email to all recipients. The changes span API, domain, messaging, and infrastructure layers to add, persist, and utilize the new `RecipientAggregationMode` option, including updates to DTOs, entities, database configuration, and email sending logic.

**Notification Rule Model & API Changes**
* Added the `RecipientAggregationMode` property to `NotificationRule`, related DTOs, and API request/response models, allowing users to specify whether notifications are sent individually or aggregated. [[1]](diffhunk://#diff-70f91a5e19933cc238e5363f4e12c3f7b781f05f63e070d58998b12ef0ae8ad9R16) [[2]](diffhunk://#diff-70f91a5e19933cc238e5363f4e12c3f7b781f05f63e070d58998b12ef0ae8ad9R38-R45) [[3]](diffhunk://#diff-025d71664efbb360bc34a11828a887f5b381b15d01620bb1f151e78ad8c3e6bbR22) [[4]](diffhunk://#diff-684a9fb5c82aa3981743e9d5cf59756c57d724891b734236b10bed722e3dceefR16) [[5]](diffhunk://#diff-caec7a04716949556e8ff168736f04c36aee6c5226cb78b87f45ecdb78534a63L14-R21)
* Updated controller and command handlers to accept, persist, and return the new aggregation mode, including logic to update the aggregation mode and ensure it is stored and retrieved correctly. [[1]](diffhunk://#diff-dd2c7e7203f799b0d4e0465693e75b40f7b3c11a8c98eb79d8f17301f3e45269L61-R62) [[2]](diffhunk://#diff-025d71664efbb360bc34a11828a887f5b381b15d01620bb1f151e78ad8c3e6bbR111-R112) [[3]](diffhunk://#diff-684a9fb5c82aa3981743e9d5cf59756c57d724891b734236b10bed722e3dceefR55-R58) [[4]](diffhunk://#diff-684a9fb5c82aa3981743e9d5cf59756c57d724891b734236b10bed722e3dceefR73) [[5]](diffhunk://#diff-9d9ae58582cc4d1ce166d4ce7d6ea5b868b73e54c04743f52aba4d1ad7a91fb0R51) [[6]](diffhunk://#diff-5816ad2c2a5f68d427473fd9692ead71f907fd76c199af397853c27ef4ebacc1R63)

**Domain Logic & Persistence**
* Implemented the `SetRecipientAggregationMode` method in the `NotificationRule` entity to update aggregation mode and track changes.
* Updated EF Core configuration to persist `RecipientAggregationMode` as an integer, with a default value of `Individual`.

**Messaging & Email Service Enhancements**
* Extended the messaging interfaces and implementations to support publishing aggregated certificate expiration notifications, including new methods and message properties to handle multiple recipients. [[1]](diffhunk://#diff-ff536386ed5e7f500b038ea96a88be004d63a7186cdc18efc5f6ae0fa5db1442R16-R18) [[2]](diffhunk://#diff-5176daeacd66f650272944e663681c2d38792f10c2739b3fbaa33631551e5d64R154-R187) [[3]](diffhunk://#diff-153f21ad232a49eddc38be3cdfdd56bed781ed5e0d5eef074591a11b7ce5c310R11-R12)
* Updated the email service to handle aggregated messages, including BCC support, validation for aggregated emails, and improved logging for aggregated sends. [[1]](diffhunk://#diff-4257ade92164ed1a96eb741e21282349f423b383f586cacce52b66d30500c5f2R15) [[2]](diffhunk://#diff-ac02feec9fa870c2f8ca0f91b0092ab0994820d3903b87b44a4994b449586d7bR46-R58) [[3]](diffhunk://#diff-ac02feec9fa870c2f8ca0f91b0092ab0994820d3903b87b44a4994b449586d7bR79-R94) [[4]](diffhunk://#diff-ac02feec9fa870c2f8ca0f91b0092ab0994820d3903b87b44a4994b449586d7bR109-R116)

**Infrastructure & Event Handling**
* Modified event handlers to send aggregated certificate notifications when the rule is configured for aggregation, including logic for notification history and error handling. [[1]](diffhunk://#diff-c1e3a5ff3f868f8445ec010b238c86c8fcc8295bd608eac60b0725d3b9079e53R206-R250) [[2]](diffhunk://#diff-c1e3a5ff3f868f8445ec010b238c86c8fcc8295bd608eac60b0725d3b9079e53R297)

**New Enums**
* Introduced the `RecipientAggregationMode` enum to represent the aggregation options (`Individual`, `SingleEmailToAll`).